### PR TITLE
Fix backtrace prints on Heroku by using stderr

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -10,12 +10,7 @@ public enum Backtrace {
             let stackSymbols: UnsafeMutableBufferPointer<UnsafeMutableRawPointer?> = .allocate(capacity: maxFrames)
             stackSymbols.initialize(repeating: nil)
             let howMany = backtrace(stackSymbols.baseAddress!, CInt(maxFrames))
-            let ptr = backtrace_symbols(stackSymbols.baseAddress!, howMany)
-            let realAddresses = Array(UnsafeBufferPointer(start: ptr, count: Int(howMany))).compactMap { $0 }
-            realAddresses.forEach {
-                fputs($0, stderr)
-                fputc(0x0A, stderr)
-            }
+            backtrace_symbols_fd(stackSymbols.baseAddress!, howMany, STDERR_FILENO)
         }
     }
 

--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -14,6 +14,7 @@ public enum Backtrace {
             let realAddresses = Array(UnsafeBufferPointer(start: ptr, count: Int(howMany))).compactMap { $0 }
             realAddresses.forEach {
                 fputs($0, stderr)
+                fputc(0x0A, stderr)
             }
         }
     }

--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -13,7 +13,7 @@ public enum Backtrace {
             let ptr = backtrace_symbols(stackSymbols.baseAddress!, howMany)
             let realAddresses = Array(UnsafeBufferPointer(start: ptr, count: Int(howMany))).compactMap { $0 }
             realAddresses.forEach {
-                print(String(cString: $0))
+                fputs($0, stderr)
             }
         }
     }


### PR DESCRIPTION
This PR fixes #6 - as far as seeing _any_ output in the logs go.