### PR TITLE
fix: capture argv[0] earlier

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -2,10 +2,12 @@
 import Glibc
 import CBacktrace
 
+private let fileName = CommandLine.arguments[0]
+
 public enum Backtrace {
     public static func install() {
         setupHandler(signal: SIGILL) { _ in
-            let state = backtrace_create_state(CommandLine.arguments[0], 1, nil, nil)
+            let state = backtrace_create_state(fileName, 1, nil, nil)
             backtrace_print(state, 5, stderr)
         }
     }


### PR DESCRIPTION
Because `CommandLine.arguments` is a mutable `var` it's better to capture it at startup, just in case it gets changed before the signal handler runs.