### PR TITLE
feat: cross-compilation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,30 +2,6 @@
 
 import PackageDescription
 
-var backtraceDependencies: [Target.Dependency] = []
-
-#if os(Linux)
-backtraceDependencies.append(.target(name: "CBacktrace"))
-#endif
-
-var targets: [Target] = [
-    .target(
-        name: "Backtrace",
-        dependencies: backtraceDependencies),
-    .testTarget(
-        name: "BacktraceTests",
-        dependencies: ["Backtrace"])
-]
-
-#if os(Linux)
-targets.append(
-    .target(
-        name: "CBacktrace",
-        dependencies: [])
-)
-#endif
-
-
 let package = Package(
     name: "swift-backtrace",
     products: [
@@ -34,5 +10,12 @@ let package = Package(
             targets: ["Backtrace"]),
     ],
     dependencies: [],
-    targets: targets
+    targets: [
+        .target(name: "Backtrace",
+                dependencies: ["CBacktrace"]),
+        .target(name: "CBacktrace",
+                dependencies: []),
+        .testTarget(name: "BacktraceTests",
+                dependencies: ["Backtrace"])
+    ]
 )

--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -2,30 +2,6 @@
 
 import PackageDescription
 
-var backtraceDependencies: [Target.Dependency] = []
-
-#if os(Linux)
-backtraceDependencies.append(.target(name: "CBacktrace"))
-#endif
-
-var targets: [Target] = [
-    .target(
-        name: "Backtrace",
-        dependencies: backtraceDependencies),
-    .testTarget(
-        name: "BacktraceTests",
-        dependencies: ["Backtrace"])
-]
-
-#if os(Linux)
-targets.append(
-    .target(
-        name: "CBacktrace",
-        dependencies: [])
-)
-#endif
-
-
 let package = Package(
     name: "swift-backtrace",
     products: [
@@ -34,5 +10,12 @@ let package = Package(
             targets: ["Backtrace"]),
     ],
     dependencies: [],
-    targets: targets
+    targets: [
+        .target(name: "Backtrace",
+                dependencies: ["CBacktrace"]),
+        .target(name: "CBacktrace",
+                dependencies: []),
+        .testTarget(name: "BacktraceTests",
+                dependencies: ["Backtrace"])
+        ]
 )

--- a/Sources/CBacktrace/atomic.c
+++ b/Sources/CBacktrace/atomic.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* atomic.c -- Support for atomic functions if not present.
    Copyright (C) 2013-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -110,4 +111,5 @@ backtrace_atomic_store_int (int *p, int v)
     old = *p;
 }
 
+#endif
 #endif

--- a/Sources/CBacktrace/backtrace-supported.h
+++ b/Sources/CBacktrace/backtrace-supported.h
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* backtrace-supported.h.in -- Whether stack backtrace is supported.
    Copyright (C) 2012-2016 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -64,3 +65,4 @@ POSSIBILITY OF SUCH DAMAGE.  */
    will work for variables.  It will always work for functions.  */
 
 #define BACKTRACE_SUPPORTS_DATA 1
+#endif

--- a/Sources/CBacktrace/backtrace.c
+++ b/Sources/CBacktrace/backtrace.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* backtrace.c -- Entry point for stack backtrace library.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -127,3 +128,4 @@ backtrace_full (struct backtrace_state *state, int skip,
   _Unwind_Backtrace (unwind, &bdata);
   return bdata.ret;
 }
+#endif

--- a/Sources/CBacktrace/config.h
+++ b/Sources/CBacktrace/config.h
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* config.h.  Generated from config.h.in by configure.  */
 /* config.h.in.  Generated from configure.ac by autoheader.  */
 
@@ -148,3 +149,4 @@
 
 /* Define to 1 if you need to in order for `stat' and other things to work. */
 /* #undef _POSIX_SOURCE */
+#endif

--- a/Sources/CBacktrace/dwarf.c
+++ b/Sources/CBacktrace/dwarf.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* dwarf.c -- Get file/line information from DWARF for backtraces.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -3124,3 +3125,4 @@ backtrace_dwarf_add (struct backtrace_state *state,
 
   return 1;
 }
+#endif

--- a/Sources/CBacktrace/elf.c
+++ b/Sources/CBacktrace/elf.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* elf.c -- Get debug data from an ELF file for backtraces.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -3338,3 +3339,4 @@ backtrace_initialize (struct backtrace_state *state, const char *filename,
 
   return 1;
 }
+#endif

--- a/Sources/CBacktrace/fileline.c
+++ b/Sources/CBacktrace/fileline.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* fileline.c -- Get file and line number information in a backtrace.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -199,3 +200,4 @@ backtrace_syminfo (struct backtrace_state *state, uintptr_t pc,
   state->syminfo_fn (state, pc, callback, error_callback, data);
   return 1;
 }
+#endif

--- a/Sources/CBacktrace/filenames.h
+++ b/Sources/CBacktrace/filenames.h
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* btest.c -- Filename header for libbacktrace library
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -46,4 +47,5 @@ POSSIBILITY OF SUCH DAMAGE.  */
 # define IS_DIR_SEPARATOR(c) ((c) == '/' || (c) == '\\')
 #else
 # define IS_DIR_SEPARATOR(c) ((c) == '/')
+#endif
 #endif

--- a/Sources/CBacktrace/include/backtrace.h
+++ b/Sources/CBacktrace/include/backtrace.h
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* backtrace.h -- Public header file for stack backtrace library.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -179,4 +180,5 @@ extern int backtrace_syminfo (struct backtrace_state *state, uintptr_t addr,
 } /* End extern "C".  */
 #endif
 
+#endif
 #endif

--- a/Sources/CBacktrace/internal.h
+++ b/Sources/CBacktrace/internal.h
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* internal.h -- Internal header file for stack backtrace library.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -301,4 +302,5 @@ extern int backtrace_uncompress_zdebug (struct backtrace_state *,
 					unsigned char **uncompressed,
 					size_t *uncompressed_size);
 
+#endif
 #endif

--- a/Sources/CBacktrace/mmap.c
+++ b/Sources/CBacktrace/mmap.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* mmap.c -- Memory allocation with mmap.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -323,3 +324,4 @@ backtrace_vector_release (struct backtrace_state *state,
   vec->alc = 0;
   return 1;
 }
+#endif

--- a/Sources/CBacktrace/mmapio.c
+++ b/Sources/CBacktrace/mmapio.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* mmapio.c -- File views using mmap.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -98,3 +99,4 @@ backtrace_release_view (struct backtrace_state *state ATTRIBUTE_UNUSED,
   if (munmap (const_cast.v, view->len) < 0)
     error_callback (data, "munmap", errno);
 }
+#endif

--- a/Sources/CBacktrace/posix.c
+++ b/Sources/CBacktrace/posix.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* posix.c -- POSIX file I/O routines for the backtrace library.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -98,3 +99,4 @@ backtrace_close (int descriptor, backtrace_error_callback error_callback,
     }
   return 1;
 }
+#endif

--- a/Sources/CBacktrace/print.c
+++ b/Sources/CBacktrace/print.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* print.c -- Print the current backtrace.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -90,3 +91,4 @@ backtrace_print (struct backtrace_state *state, int skip, FILE *f)
   backtrace_full (state, skip + 1, print_callback, error_callback,
 		  (void *) &data);
 }
+#endif

--- a/Sources/CBacktrace/simple.c
+++ b/Sources/CBacktrace/simple.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* simple.c -- The backtrace_simple function.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -106,3 +107,4 @@ backtrace_simple (struct backtrace_state *state, int skip,
   _Unwind_Backtrace (simple_unwind, &bdata);
   return bdata.ret;
 }
+#endif

--- a/Sources/CBacktrace/sort.c
+++ b/Sources/CBacktrace/sort.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* sort.c -- Sort without allocating memory
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -106,3 +107,4 @@ backtrace_qsort (void *basearg, size_t count, size_t size,
       goto tail_recurse;
     }
 }
+#endif

--- a/Sources/CBacktrace/state.c
+++ b/Sources/CBacktrace/state.c
@@ -1,3 +1,4 @@
+#ifdef __linux__
 /* state.c -- Create the backtrace state.
    Copyright (C) 2012-2018 Free Software Foundation, Inc.
    Written by Ian Lance Taylor, Google.
@@ -70,3 +71,4 @@ backtrace_create_state (const char *filename, int threaded,
 
   return state;
 }
+#endif

--- a/scripts/vendor-libbacktrace.sh
+++ b/scripts/vendor-libbacktrace.sh
@@ -69,4 +69,7 @@ mv "$DSTROOT/backtrace.h" "$DSTROOT/include"
 echo "REPLACING references to \"backtrace.h\" with \"include/backtrace.h\""
 find $DSTROOT -name "*.[ch]" -print0 | xargs -0 sed -i -e 's#"backtrace.h"#"include/backtrace.h"#g'
 
+echo "ADDING preprocessor conditionals"
+find $DSTROOT -name "*.[ch]" -print0 | xargs -0 sed -i -e '1i#ifdef __linux__' -e '$a#endif'
+
 echo "DONE"


### PR DESCRIPTION
It's best practice to avoid platform conditional code in `Package.swift`.

1. Change the vendoring script so it wraps all the C code in `#ifdef __linux__`, so it can compile on macOS too (but does nothing).
2. Re-run the script so the C code is appropriately wrapped.
3. Update the `Package.swift` files to remove the conditional compilation.

Result: happy cross-compilers

Fixes: #16 

CC: @weissi