### PR TITLE
Adding instructions for integrating Backtrace with swift-service-lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ $ swift build -c release -Xswiftc -g
 
 When your app crashes, a stacktrace will be printed to `stderr`.
 
+### Integrating Backtrace with swift-service-lifecycle
+
+If you are using swift-service-lifecycle https://github.com/swift-server/swift-service-lifecycle, you can trigger a register a backtrace by adding the following to your lifecycle:
+
+```
+import Backtrace
+
+lifecycle.registerShutdown(label: "backtrace",.sync(Backtrace.print))
+```
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ When your app crashes, a stacktrace will be printed to `stderr`.
 
 ### Integrating Backtrace with swift-service-lifecycle
 
-If you are using swift-service-lifecycle https://github.com/swift-server/swift-service-lifecycle, you can trigger a register a backtrace by adding the following to your lifecycle:
+If you are using swift-service-lifecycle https://github.com/swift-server/swift-service-lifecycle, using the Backtrace.install() command will interfere with the shutdown lifecycle.  Instead, add Backtrace.print to your lifecycle:
 
 ```swift
 import Backtrace
 
 lifecycle.registerShutdown(label: "backtrace",.sync(Backtrace.print))
 ```
+
 
 ## Acknowledgements
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ When your app crashes, a stacktrace will be printed to `stderr`.
 
 If you are using swift-service-lifecycle https://github.com/swift-server/swift-service-lifecycle, you can trigger a register a backtrace by adding the following to your lifecycle:
 
-```
+```swift
 import Backtrace
 
 lifecycle.registerShutdown(label: "backtrace",.sync(Backtrace.print))


### PR DESCRIPTION
Swift-server just announced https://github.com/swift-server/swift-service-lifecycle

The current Backtrace instructions interfere with the swift-service-lifecycle shutdown signal handling.  This PR adds alternate instructions for adding Backtrace to the swift-service-lifecycle.

Only concern is I needed to register a function with no arguments, so I used the deprecated Backtrace.print() function.  Given the benefits of swift-service-lifecycle handling the interrupts, I suggest un-deprecating Backtrace.print().

For testing, here's my main.swift from my Netrek Server, which is successfully using lifecycle and backtrace:

https://github.com/darrellroot/netrek-server-swift/blob/master/Sources/netrek-server-swift/Lifecycle/main.swift

And here's output from a shutdown.  Note the backtrace.  One other concern is whether the backtraces in general will be useful if they always come via the lifecycle.

netrek@netrek-server-swift:~$ ./netrek-server-swift/.build/x86_64-unknown-linux-gnu/debug/netrek-server-swift --directory /home/netrek/netrek-data --empire
Initializing server
saving data
Server started and listening on [IPv6]::/:::2592
Starting Run Loop
^C0x5617d90e5ed9, static Backtrace.Backtrace.print() -> () at /home/netrek/netrek-server-swift/.build/checkouts/swift-backtrace/Sources/Backtrace/Backtrace.swift:73
0x5617d92a40d9, closure #1 ((Swift.Optional<Swift.Error>) -> ()) -> () in static Lifecycle.LifecycleHandler.sync(() throws -> ()) -> Lifecycle.LifecycleHandler at /home/netrek/netrek-server-swift/.build/checkouts/swift-service-lifecycle/Sources/Lifecycle/Lifecycle.swift:62
0x5617d92a4312, Lifecycle.LifecycleHandler.run((Swift.Optional<Swift.Error>) -> ()) -> () at /home/netrek/netrek-server-swift/.build/checkouts/swift-service-lifecycle/Sources/Lifecycle/Lifecycle.swift:78
0x5617d92ad6ab, Lifecycle.ComponentLifecycle.Task.shutdown((Swift.Optional<Swift.Error>) -> ()) -> () at /home/netrek/netrek-server-swift/.build/checkouts/swift-service-lifecycle/Sources/Lifecycle/Lifecycle.swift:477
0x5617d92ad78d, protocol witness for Lifecycle.LifecycleTask.shutdown((Swift.Optional<Swift.Error>) -> ()) -> () in conformance Lifecycle.ComponentLifecycle.Task : Lifecycle.LifecycleTask in Lifecycle at /home/netrek/netrek-server-swift/<compiler-generated>:0
0x5617d92ac48b, closure #1 () -> () in closure #1 ((Swift.Optional<Swift.Error>) -> ()) -> () in Lifecycle.ComponentLifecycle.(shutdownTask in _E72740DFB8F1D6E6BB04AB9A64070EAA)(on: Dispatch.DispatchQueue, tasks: Swift.Array<Lifecycle.LifecycleTask>, index: Swift.Int, errors: Swift.Optional<Swift.Dictionary<Swift.String, Swift.Error>>, callback: (Swift.Optional<Swift.Dictionary<Swift.String, Swift.Error>>) -> ()) -> () at /home/netrek/netrek-server-swift/.build/checkouts/swift-service-lifecycle/Sources/Lifecycle/Lifecycle.swift:433
0x5617d92a553f, reabstraction thunk helper from @escaping @callee_guaranteed () -> () to @escaping @callee_unowned @convention(block) () -> () at /home/netrek/netrek-server-swift/<compiler-generated>:0
0x7f637c8df986
0x7f637c8f4037
0x7f637d2dd608
0x7f637c7ca102
0xffffffffffffffff
saving data
sending shutdown warnings
shutdown complete
