### PR TITLE
remove symbolicate-linux-fatal from Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,10 +24,6 @@ RUN if [ "${ubuntu_version}" != "xenial" ] ; then gem install jazzy --no-ri --no
 RUN mkdir -p $HOME/.tools
 RUN echo 'export PATH="$HOME/.tools:$PATH"' >> $HOME/.profile
 
-# script to allow mapping framepointers on linux (until part of the toolchain)
-RUN wget -q https://raw.githubusercontent.com/apple/swift/master/utils/symbolicate-linux-fatal -O $HOME/.tools/symbolicate-linux-fatal
-RUN chmod 755 $HOME/.tools/symbolicate-linux-fatal
-
 # swiftformat (until part of the toolchain)
 
 ARG swiftformat_version=0.44.6


### PR DESCRIPTION
motivation: we are not actually using symbolicate-linux-fatal in any meaningful way in CI and it's pinned to the master branch which has been removed

changes: remove symbolicate-linux-fatal fetching from Docker