### PR TITLE
better distinguish mmap errors & print errno

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -53,10 +53,10 @@ private let fullCallback: CBacktraceFullCallback? = {
 }
 
 private let errorCallback: CBacktraceErrorCallback? = {
-    _, msg, _ in
+    _, msg, errNo in
     if let msg = msg {
-        _ = withVaList([msg]) { vaList in
-            vfprintf(stderr, "%s\n", vaList)
+        _ = withVaList([msg, errNo]) { vaList in
+            vfprintf(stderr, "SwiftBacktrace ERROR: %s (errno: %d)\n", vaList)
         }
     }
 }

--- a/Sources/CBacktrace/mmap.c
+++ b/Sources/CBacktrace/mmap.c
@@ -170,7 +170,7 @@ backtrace_alloc (struct backtrace_state *state,
       if (page == MAP_FAILED)
 	{
 	  if (error_callback)
-	    error_callback (data, "mmap", errno);
+	    error_callback (data, "mmap for alloc", errno);
 	}
       else
 	{

--- a/Sources/CBacktrace/mmapio.c
+++ b/Sources/CBacktrace/mmapio.c
@@ -71,7 +71,7 @@ backtrace_get_view (struct backtrace_state *state ATTRIBUTE_UNUSED,
   map = mmap (NULL, size, PROT_READ, MAP_PRIVATE, descriptor, pageoff);
   if (map == MAP_FAILED)
     {
-      error_callback (data, "mmap", errno);
+      error_callback (data, "mmap file i/o", errno);
       return 0;
     }
 


### PR DESCRIPTION
Motivation:

In case SwiftBacktrace fails, we get only very little output.
Unfortunately, some crucial information (like the errno) is missing and
in case `mmap` fails, we don't know if the problem is file I/O or
allocating memory.

Modification:

- print errnos
- distinguish the two mmaps

Result:

Easier debugging