### PR TITLE
determine the executable path automatically

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -21,7 +21,7 @@ typealias CBacktraceFullCallback = @convention(c) (_ data: UnsafeMutableRawPoint
 typealias CBacktraceSimpleCallback = @convention(c) (_ data: UnsafeMutableRawPointer?, _ pc: UInt) -> CInt
 typealias CBacktraceSyminfoCallback = @convention(c) (_ data: UnsafeMutableRawPointer?, _ pc: UInt, _ filename: UnsafePointer<CChar>?, _ symval: UInt, _ symsize: UInt) -> Void
 
-private let state = backtrace_create_state(CommandLine.arguments[0], /* BACKTRACE_SUPPORTS_THREADS */ 1, nil, nil)
+private let state = backtrace_create_state(nil, /* BACKTRACE_SUPPORTS_THREADS */ 1, nil, nil)
 
 private let fullCallback: CBacktraceFullCallback? = {
     _, pc, filename, lineno, function in

--- a/Sources/CBacktrace/fileline.c
+++ b/Sources/CBacktrace/fileline.c
@@ -94,13 +94,13 @@ fileline_initialize (struct backtrace_state *state,
 	  filename = state->filename;
 	  break;
 	case 1:
-	  filename = getexecname ();
-	  break;
-	case 2:
 	  filename = "/proc/self/exe";
 	  break;
-	case 3:
+	case 2:
 	  filename = "/proc/curproc/file";
+	  break;
+	case 3:
+	  filename = getexecname ();
 	  break;
 	case 4:
 	  snprintf (buf, sizeof (buf), "/proc/%ld/object/a.out",


### PR DESCRIPTION
Motivation:

Previously, we would use
`CommandLine.arguments[0]`/`argv[0]`/`getexecname()` as the preferred
ways to find the main binary. That sounds sensible, especially given
the fact that we'd fall back onto other methods (such as
`/proc/self/exe`) when the previous ones don't work.

There is however an unfortunate edge case. If you for example have your
app binary at `/app/app` and you start it with a relative path `./app`
from within `/app`, then `CommandLine.arguments[0]` will only contain
`./app`. If now the app changes its working directory to `/`, `./app`
would mean `/app` which is the directory. This would mean we will find
the target but instead of the binary we'd find the directory `/app`.
From then on, everything else fails.

A similar problem is if `argv[0]` was actually set incorrectly when
`exec*`ing the process. This has happened at least in one instance.

Thanks very much to @khanlou for the initial bug report and patently
deploying over and over again until we could reduce the bug and @helje5
for helping to debug this!

Modification:

Given that we only target Linux here, we can actually here, we can
change the order in which we try to find the main binary. We can start
by using `/proc/self/exe` which is a very high quality and almost
guaranteed to work way to find the main binary, nevermind the
information in `argv`.

Result:

More robust symbolications, especially in environments like Heroku/Dokku
where we've seen `argv` not being set correctly.