### PR TITLE
Update build flags with Swift version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ import Backtrace
 Backtrace.install()
 ```
 
-Finally, make sure you build your application with debug symbols enabled:
+Finally, for Swift < 5.2, make sure you build your application with debug symbols enabled. Debug symbols are automatically included for Swift 5.2 and above.
 
 ```
 $ swift build -c release -Xswiftc -g


### PR DESCRIPTION
As of Swift 5.2, this build flag is no longer necessary.