### PR TITLE
Backtrace: enable support for Windows

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -174,7 +174,7 @@ public enum Backtrace {
 
                 let module: String = withUnsafeMutablePointer(to: &qwModuleBase) {
                     $0.withMemoryRebound(to: HINSTANCE.self, capacity: 1) { hInstance in
-                        String(decoding: Array<WCHAR>(unsafeUninitializedCapacity: Int(MAX_PATH + 1)) {
+                        String(decoding: [WCHAR](unsafeUninitializedCapacity: Int(MAX_PATH + 1)) {
                             $1 = Int(GetModuleFileNameW(hInstance.pointee,
                                                         $0.baseAddress,
                                                         DWORD($0.count)))


### PR DESCRIPTION
Add an implementation across all architectures supported by Windows:
- x86
- x86_64
- ARM
- ARM64

This relies on DbgHlp32.dll which makes this unfriendly to store
applications.  We can investigate improvements to that in the future.
This sketches out an implementation which allows building and using the
interface for providing backtraces.  This requires that the programs be
built with debug information in CodeView format.  Without the additional
debug information, the stack traces will be limited to symbolication and
resolution to export only symbols.

Resolves: #34