### PR TITLE
trap SIGSEGV by default, in addition to SIGILL

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -67,9 +67,9 @@ private func printBacktrace(signal: CInt) {
 }
 
 public enum Backtrace {
-    /// Install the backtrace handler on `SIGILL`.
+    /// Install the backtrace handler on default signals: `SIGILL`, `SIGSEGV`, `SIGBUS`, `SIGFPE`.
     public static func install() {
-        Backtrace.install(signals: [SIGILL, SIGSEGV])
+        Backtrace.install(signals: [SIGILL, SIGSEGV, SIGBUS, SIGFPE])
     }
 
     /// Install the backtrace handler when any of `signals` happen.

--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -69,7 +69,7 @@ private func printBacktrace(signal: CInt) {
 public enum Backtrace {
     /// Install the backtrace handler on `SIGILL`.
     public static func install() {
-        Backtrace.install(signals: [SIGILL])
+        Backtrace.install(signals: [SIGILL, SIGSEGV])
     }
 
     /// Install the backtrace handler when any of `signals` happen.

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -31,6 +31,10 @@ case "SIGILL":
     raiseSignal(SIGILL)
 case "SIGSEGV":
     raiseSignal(SIGSEGV)
+case "SIGBUS":
+    raiseSignal(SIGBUS)
+case "SIGFPE":
+    raiseSignal(SIGFPE)
 default:
     fatalError(reason)
 }

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -13,7 +13,24 @@
 //===----------------------------------------------------------------------===//
 
 import Backtrace
+#if canImport(Darwin)
+import Darwin
+#elseif os(Linux)
+import Glibc
+#endif
+
+Backtrace.install()
+
+func raiseSignal(_ signal: Int32) {
+    raise(signal)
+}
 
 let reason = CommandLine.arguments.count == 2 ? CommandLine.arguments[1] : "unknown"
-Backtrace.install()
-fatalError(reason)
+switch reason.uppercased() {
+case "SIGILL":
+    raiseSignal(SIGILL)
+case "SIGSEGV":
+    raiseSignal(SIGSEGV)
+default:
+    fatalError(reason)
+}

--- a/Tests/BacktraceTests/BacktraceTests+XCTest.swift
+++ b/Tests/BacktraceTests/BacktraceTests+XCTest.swift
@@ -28,6 +28,8 @@ extension BacktraceTests {
             ("testFatalError", testFatalError),
             ("testSIGILL", testSIGILL),
             ("testSIGSEGV", testSIGSEGV),
+            ("testSIGBUS", testSIGBUS),
+            ("testSIGFPE", testSIGFPE),
         ]
     }
 }

--- a/Tests/BacktraceTests/BacktraceTests+XCTest.swift
+++ b/Tests/BacktraceTests/BacktraceTests+XCTest.swift
@@ -25,7 +25,9 @@ import XCTest
 extension BacktraceTests {
     public static var allTests: [(String, (BacktraceTests) -> () throws -> Void)] {
         return [
-            ("testBacktrace", testBacktrace),
+            ("testFatalError", testFatalError),
+            ("testSIGILL", testSIGILL),
+            ("testSIGSEGV", testSIGSEGV),
         ]
     }
 }

--- a/Tests/BacktraceTests/BacktraceTests.swift
+++ b/Tests/BacktraceTests/BacktraceTests.swift
@@ -37,7 +37,7 @@ public final class BacktraceTests: XCTestCase {
         let stderr = try runSample(reason: "SIGILL")
         print(stderr)
 
-        XCTAssert(stderr.contains("Received signal 4. Backtrace:"))
+        XCTAssert(stderr.contains("Received signal \(SIGILL). Backtrace:"))
         XCTAssert(stderr.contains("Sample.raiseSignal"))
     }
 
@@ -49,7 +49,31 @@ public final class BacktraceTests: XCTestCase {
         let stderr = try runSample(reason: "SIGSEGV")
         print(stderr)
 
-        XCTAssert(stderr.contains("Received signal 11. Backtrace:"))
+        XCTAssert(stderr.contains("Received signal \(SIGSEGV). Backtrace:"))
+        XCTAssert(stderr.contains("Sample.raiseSignal"))
+    }
+
+    func testSIGBUS() throws {
+        #if !os(Linux)
+        try XCTSkipIf(true, "test is only supported on Linux")
+        #endif
+
+        let stderr = try runSample(reason: "SIGBUS")
+        print(stderr)
+
+        XCTAssert(stderr.contains("Received signal \(SIGBUS). Backtrace:"))
+        XCTAssert(stderr.contains("Sample.raiseSignal"))
+    }
+
+    func testSIGFPE() throws {
+        #if !os(Linux)
+        try XCTSkipIf(true, "test is only supported on Linux")
+        #endif
+
+        let stderr = try runSample(reason: "SIGFPE")
+        print(stderr)
+
+        XCTAssert(stderr.contains("Received signal \(SIGFPE). Backtrace:"))
         XCTAssert(stderr.contains("Sample.raiseSignal"))
     }
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -34,4 +34,4 @@ services:
 
   shell:
     <<: *common
-    entrypoint: /bin/bash
+    entrypoint: /bin/bash -l


### PR DESCRIPTION
motivation: print crash trace on segmentaiton fault

changes:
* include SIGSEGV in the default signals trapped
* update and improve tests