### PR TITLE
flush stderr after printing backtraces

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -64,6 +64,7 @@ private let errorCallback: CBacktraceErrorCallback? = {
 private func printBacktrace(signal: CInt) {
     _ = fputs("Received signal \(signal). Backtrace:\n", stderr)
     backtrace_full(state, /* skip */ 0, fullCallback, errorCallback, nil)
+    fflush(stderr)
 }
 
 public enum Backtrace {


### PR DESCRIPTION
motivation: make sure stderr buffered is printed out before program exits (in case stderr is buffered)

changes: explicitly call fflush after writing the backtraces