### PR TITLE
Disable this library for Swift 5.9 and above.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ When this gap is closed at the language runtime level, this library will become 
 
 ## Usage
 
-When building web-services and daemons, direct usage of this library is discouraged. 
-Instead, use [swift-service-lifecycle](https://github.com/swift-server/swift-service-lifecycle) which helps manage the application lifecycle including setting up backtraces hooks when needed. 
+**Note**: You do not need this library on Linux as of Swift 5.9, which has
+built-in backtracing support.
 
 Add `https://github.com/swift-server/swift-backtrace.git` as a dependency in your `Package.swift`.
 

--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -12,7 +12,21 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if os(Linux)
+// Swift 5.9 has its own built-in backtracing support in the runtime;
+// we don't want to activate this library if we're using 5.9 or above.
+#if swift(>=5.9) && !os(Windows)
+public enum Backtrace {
+    @available(*, deprecated, message: "This is no longer needed in Swift 5.9")
+    public static func install() {}
+
+    @available(*, deprecated, message: "This is no longer needed in Swift 5.9")
+    public static func install(signals: [CInt]) {}
+
+    @available(*, deprecated, message: "This method will be removed in the next major version.")
+    public static func print() {}
+}
+
+#elseif os(Linux)
 import CBacktrace
 import Glibc
 

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -19,7 +19,9 @@ import Darwin
 import Glibc
 #endif
 
+#if swift(<5.9) || os(Windows)
 Backtrace.install()
+#endif
 
 func raiseSignal(_ signal: Int32) {
     raise(signal)

--- a/Tests/BacktraceTests/BacktraceTests.swift
+++ b/Tests/BacktraceTests/BacktraceTests.swift
@@ -20,6 +20,10 @@ public final class BacktraceTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on Linux")
         #endif
 
+        #if swift(>=5.9)
+        try XCTSkipIf(true, "test is not supported on Swift 5.9")
+        #endif
+
         let expectedError = UUID().uuidString
         let stderr = try runSample(reason: expectedError)
         print(stderr)
@@ -34,6 +38,10 @@ public final class BacktraceTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on Linux")
         #endif
 
+        #if swift(>=5.9)
+        try XCTSkipIf(true, "test is not supported on Swift 5.9")
+        #endif
+
         let stderr = try runSample(reason: "SIGILL")
         print(stderr)
 
@@ -44,6 +52,10 @@ public final class BacktraceTests: XCTestCase {
     func testSIGSEGV() throws {
         #if !os(Linux)
         try XCTSkipIf(true, "test is only supported on Linux")
+        #endif
+
+        #if swift(>=5.9)
+        try XCTSkipIf(true, "test is not supported on Swift 5.9")
         #endif
 
         let stderr = try runSample(reason: "SIGSEGV")
@@ -58,6 +70,10 @@ public final class BacktraceTests: XCTestCase {
         try XCTSkipIf(true, "test is only supported on Linux")
         #endif
 
+        #if swift(>=5.9)
+        try XCTSkipIf(true, "test is not supported on Swift 5.9")
+        #endif
+
         let stderr = try runSample(reason: "SIGBUS")
         print(stderr)
 
@@ -68,6 +84,10 @@ public final class BacktraceTests: XCTestCase {
     func testSIGFPE() throws {
         #if !os(Linux)
         try XCTSkipIf(true, "test is only supported on Linux")
+        #endif
+
+        #if swift(>=5.9)
+        try XCTSkipIf(true, "test is not supported on Swift 5.9")
         #endif
 
         let stderr = try runSample(reason: "SIGFPE")


### PR DESCRIPTION
Swift 5.9 has a new built-in backtrace-on-crash facility, which supersedes this library.

rdar://111109405