### PR TITLE
Support compiling against Musl

### DIFF
--- a/Sources/Backtrace/Backtrace.swift
+++ b/Sources/Backtrace/Backtrace.swift
@@ -28,7 +28,13 @@ public enum Backtrace {
 
 #elseif os(Linux)
 import CBacktrace
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
+#endif
 
 typealias CBacktraceErrorCallback = @convention(c) (_ data: UnsafeMutableRawPointer?, _ msg: UnsafePointer<CChar>?, _ errnum: CInt) -> Void
 typealias CBacktraceFullCallback = @convention(c) (_ data: UnsafeMutableRawPointer?, _ pc: UInt, _ filename: UnsafePointer<CChar>?, _ lineno: CInt, _ function: UnsafePointer<CChar>?) -> CInt

--- a/Sources/Backtrace/Demangle.swift
+++ b/Sources/Backtrace/Demangle.swift
@@ -13,7 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 #if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
+#endif
 #elseif os(Windows)
 #if swift(<5.4)
 #error("unsupported Swift version")

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -16,7 +16,13 @@ import Backtrace
 #if canImport(Darwin)
 import Darwin
 #elseif os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
+#else
+#error("Unsupported runtime")
+#endif
 #endif
 
 #if swift(<5.9) || os(Windows)


### PR DESCRIPTION
### Motivation

When building for Linux, we would like to be able to build this package on top of Musl, as well as the usual Glibc.

### Modifications

Replace imports of Glibc with conditional imports using the following pattern:

```diff
- import Glibc
+ #if canImport(Glibc)
+ import Glibc
+ #elseif canImport(Musl)
+ import Musl
+ #else
+ #error("Unsupported runtime")
+ #endif
```

### Result

Can compile against Musl.