### PR TITLE
Do not build Demangle on Swift 5.9 or above

### DIFF
--- a/Sources/Backtrace/Demangle.swift
+++ b/Sources/Backtrace/Demangle.swift
@@ -12,6 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Swift 5.9 has its own built-in backtracing support in the runtime;
+// we don't want to activate this library if we're using 5.9 or above.
+#if !(swift(>=5.9) && !os(Windows))
+
 #if os(Linux)
 import Glibc
 #elseif os(Windows)
@@ -54,4 +58,6 @@ internal func _stdlib_demangleName(_ mangledName: String) -> String {
         return mangledName
     }
 }
+#endif
+
 #endif

--- a/Sources/Sample/main.swift
+++ b/Sources/Sample/main.swift
@@ -15,8 +15,10 @@
 import Backtrace
 #if canImport(Darwin)
 import Darwin
-#elseif os(Linux)
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 #if swift(<5.9) || os(Windows)


### PR DESCRIPTION
Pull request #68 prevents Backtrace from being built on Swift 5.9 and above, but Demangle is still built and fails when the importing project uses musl.